### PR TITLE
Check compatibility

### DIFF
--- a/src/license_analysis.py
+++ b/src/license_analysis.py
@@ -526,3 +526,75 @@ class LicenseAnalyzer(object):
         output['representative_license'] = None
         return output
 
+    def _get_compatibility_classes(self, input_license):
+        list_comp_classes = []
+        for item in self.dict_compatibility_classes.items():
+            if input_license in item[1]:
+                list_comp_classes.append(item[0])
+
+        return list_comp_classes
+
+    def check_compatibility(self, lic_a, list_lic_b):
+        output = {
+            'status': 'Failure',
+            'reason': 'Input is invalid',
+            'unknown_licenses': [],
+            'conflict_licenses': [],
+            'compatible_licenses': [],
+            'synonyms': []
+        }
+        if lic_a is None:
+            return output
+        if len(list_lic_b) == 0:
+            return output
+
+        # find synonyms
+        lic_a = self.find_synonym(lic_a)
+        list_lic_b_sysnonyms = [self.find_synonym(y) for y in list_lic_b]
+        output['synonyms'] = dict(list(zip(list_lic_b, list_lic_b_sysnonyms)))
+
+        # check if all input licenses are known
+        if len(set(list_lic_b_sysnonyms) - set(self.known_licenses)) > 0:
+            output['unknown_licenses'] = list(set(list_lic_b_sysnonyms) - set(self.known_licenses))
+            list_lic_b_sysnonyms = list(set(list_lic_b_sysnonyms).intersection(set(self.known_licenses)))
+
+            if len(list_lic_b_sysnonyms) == 0:
+                output['status'] = 'Failure'
+                output['reason'] = 'All the input licenses are unknown!'
+                return output
+
+        # we will now work with the synonyms
+        list_lic_b = list_lic_b_sysnonyms
+
+        # now, we need to find compatibility class for lic_b and every lic_b
+        lic_a_group = self._get_compatibility_classes(lic_a)
+        assert(len(lic_a_group) > 0)
+        lic_b_groups = {}
+        for lic_b in list_lic_b:
+            lic_b_groups[lic_b] = self._get_compatibility_classes(lic_b)
+
+        # initialize dict that maps every lic_b to one of lic_a's compatibility classes
+        list_items = [(x, []) for x in lic_a_group]
+        map_compatibility = dict(list_items)
+
+        # create groups of licenses that are compatible with the given input license
+        list_conflicting_licenses = []
+        for lic_b in list_lic_b:
+            common_groups = set(lic_b_groups[lic_b]).intersection(lic_a_group)
+            if len(common_groups) > 0:
+                for g in common_groups:
+                    map_compatibility[g].append(lic_b)
+            else:
+                list_conflicting_licenses.append(lic_b)
+
+        # deduplicate the list of lists of compatible licenses
+        list_compatible_licenses = [x for x in map_compatibility.values() if len(x) > 0]
+        set_compatible_licenses = set(tuple(x) for x in list_compatible_licenses)
+        list_compatible_licenses = [list(x) for x in set_compatible_licenses]
+
+        output['status'] = 'Successful'
+        output['reason'] = 'Compatibility and/or conflict identified'
+        output['conflict_licenses'] = list_conflicting_licenses
+        output['compatible_licenses'] = list_compatible_licenses
+
+        return output

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -20,8 +20,6 @@ app = Flask(__name__)
 app.config.from_object('config')
 CORS(app)
 
-global stack_license_analyzer
-
 
 @app.before_first_request
 def load_model():

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -5,7 +5,7 @@ from flask import Flask, request
 from flask_cors import CORS
 import sys
 import logging
-from .stack_license import compute_stack_license
+from stack_license import compute_stack_license
 
 
 # Python2.x: Make default encoding as UTF-8

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -5,7 +5,7 @@ from flask import Flask, request
 from flask_cors import CORS
 import sys
 import logging
-from stack_license import compute_stack_license
+from stack_license import StackLicenseAnalyzer
 
 
 # Python2.x: Make default encoding as UTF-8
@@ -20,6 +20,13 @@ app = Flask(__name__)
 app.config.from_object('config')
 CORS(app)
 
+global stack_license_analyzer
+
+
+@app.before_first_request
+def load_model():
+    app.stack_license_analyzer = StackLicenseAnalyzer()
+
 
 @app.route('/')
 def heart_beat():
@@ -31,7 +38,7 @@ def stack_license():
     input_json = request.get_json(force=True)
     # app.logger.debug("Stack analysis input: {}".format(input_json))
 
-    response = compute_stack_license(payload=input_json)
+    response = app.stack_license_analyzer.compute_stack_license(payload=input_json)
     # app.logger.debug("Stack analysis output: {}".format(response))
 
     return flask.jsonify(response)

--- a/src/stack_license.py
+++ b/src/stack_license.py
@@ -74,16 +74,6 @@ class StackLicenseAnalyzer(object):
         }
         return output
 
-    @staticmethod
-    def _generate_conflict_pairs(list_pkg1, list_pkg2):
-        list_tuples = []
-        for pkg1 in list_pkg1:
-            for pkg2 in list_pkg2:
-                list_tuples.append((pkg1, pkg2))
-
-        return
-
-
     def compute_stack_license(self, payload):
         """
         Function to perform a detailed license analysis for the given list of

--- a/src/stack_license.py
+++ b/src/stack_license.py
@@ -8,122 +8,125 @@ from src import config
 from src.util.data_store.local_filesystem import LocalFileSystem
 
 
-def compute_stack_license(payload):
-    """
-    Function to perform a detailed license analysis for the given list of
-    packages.
-
-    It first identifies representative license for each package. Then, it
-    computes representative license for the entire stack itself.
-
-    If there is any unknown license, this function will give up.
-
-    If there is any conflict then it returns pairs of conflicting licenses.
-
-    If a representative stack-license is possible, then it tries to identify
-    license based outlier packages.
-
-    :param payload: Input list of package information
-    :return: Detailed license analysis output
-    """
-    output = payload  # output info will be inserted inside payload structure
-    output['conflict_packages'] = []
-    output['outlier_packages'] = {}
-
-    try:
-        # Check input
-        if payload is None or len(payload['packages']) == 0:
-            output['status'] = 'Failure'
-            output['message'] = 'Input was invalid'
-            logging.debug("stack license analysis input is invalid")
-            return output
-
+class StackLicenseAnalyzer(object):
+    def __init__(self):
         # Data store where license graph is available
         src_dir = os.path.join(config.DATA_DIR, "license_graph")
         graph_store = LocalFileSystem(src_dir=src_dir)
         synonyms_dir = os.path.join(config.DATA_DIR, "synonyms")
         synonyms_store = LocalFileSystem(src_dir=synonyms_dir)
 
-        # First, let us try to compute representative license for each component
-        license_analyzer = LicenseAnalyzer(graph_store, synonyms_store)
-        list_comp_rep_licenses = []
-        is_stack_license_possible = True
-        for pkg in output['packages']:
-            la_output = license_analyzer.compute_representative_license(pkg.get('licenses', []))
+        self.license_analyzer = LicenseAnalyzer(graph_store, synonyms_store)
 
-            pkg['license_analysis'] = {
-                'status': la_output['status'],
-                '_representative_licenses': la_output['representative_license'],
-                'conflict_licenses': la_output['conflict_licenses'],
-                'unknown_licenses': la_output['unknown_licenses'],
-                'outlier_licenses': la_output['outlier_licenses'],
-                'synonyms': la_output['synonyms'],
-                '_message': la_output['reason']
-            }
+    def compute_stack_license(self, payload):
+        """
+        Function to perform a detailed license analysis for the given list of
+        packages.
+
+        It first identifies representative license for each package. Then, it
+        computes representative license for the entire stack itself.
+
+        If there is any unknown license, this function will give up.
+
+        If there is any conflict then it returns pairs of conflicting licenses.
+
+        If a representative stack-license is possible, then it tries to identify
+        license based outlier packages.
+
+        :param payload: Input list of package information
+        :return: Detailed license analysis output
+        """
+        output = payload  # output info will be inserted inside payload structure
+        output['conflict_packages'] = []
+        output['outlier_packages'] = {}
+
+        try:
+            # Check input
+            if payload is None or len(payload['packages']) == 0:
+                output['status'] = 'Failure'
+                output['message'] = 'Input was invalid'
+                logging.debug("stack license analysis input is invalid")
+                return output
+
+            # First, let us try to compute representative license for each component
+            list_comp_rep_licenses = []
+            is_stack_license_possible = True
+            for pkg in output['packages']:
+                la_output = self.license_analyzer.compute_representative_license(pkg.get('licenses', []))
+
+                pkg['license_analysis'] = {
+                    'status': la_output['status'],
+                    '_representative_licenses': la_output['representative_license'],
+                    'conflict_licenses': la_output['conflict_licenses'],
+                    'unknown_licenses': la_output['unknown_licenses'],
+                    'outlier_licenses': la_output['outlier_licenses'],
+                    'synonyms': la_output['synonyms'],
+                    '_message': la_output['reason']
+                }
+
+                if la_output['status'] == 'Conflict':
+                    output['status'] = 'ComponentLicenseConflict'
+                    is_stack_license_possible = False
+                elif la_output['status'] == 'Unknown':
+                    output['status'] = 'Unknown'
+                    is_stack_license_possible = False
+
+                if la_output['representative_license'] is None:
+                    # This will later indicate that no need to compute stack license
+                    is_stack_license_possible = False
+                else:
+                    list_comp_rep_licenses.append(la_output['representative_license'])
+
+            # Return if we could not compute license for some component
+            if is_stack_license_possible is False:
+                # output['status'] should have been set already
+                output['stack_license'] = None
+                output['message'] = "Component license not available. Cannot compute stack license."
+                return output
+
+            # If there is no component license then something unexpected happened
+            if len(list_comp_rep_licenses) == 0:
+                output['status'] = 'Failure'
+                output['stack_license'] = None
+                output['message'] = "Something weird happened!"
+
+            # Prepare a map of license -> package, which is used later to prepare output
+            assert(len(output['packages']) == len(list_comp_rep_licenses))
+            dict_lic_pkg = {}
+            for i, lic in enumerate(list_comp_rep_licenses):
+                pkg = output['packages'][i]
+                dict_lic_pkg[lic] = pkg.get('package', 'unknown_package')
+
+            # If we reach here, then that means we are all set to compute stack license !
+            la_output = self.license_analyzer.compute_representative_license(list_comp_rep_licenses)
+            output['status'] = la_output['status']
+            output['stack_license'] = la_output['representative_license']
 
             if la_output['status'] == 'Conflict':
-                output['status'] = 'ComponentLicenseConflict'
-                is_stack_license_possible = False
-            elif la_output['status'] == 'Unknown':
-                output['status'] = 'Unknown'
-                is_stack_license_possible = False
+                list_conflict_lic = la_output['conflict_licenses']
+                list_conflict_pkg = []
+                for lic_tuple in list_conflict_lic:
+                    pkg_group = {
+                        dict_lic_pkg[lic_tuple[0]]: lic_tuple[0],
+                        dict_lic_pkg[lic_tuple[1]]: lic_tuple[1]
+                    }
+                    list_conflict_pkg.append(pkg_group)
+                output['conflict_packages'] = list_conflict_pkg
+                output['status'] = 'StackLicenseConflict'
 
-            if la_output['representative_license'] is None:
-                # This will later indicate that no need to compute stack license
-                is_stack_license_possible = False
+            if (len(la_output['outlier_licenses'])) > 0:
+                outlier_pkg = {}
+                for lic in la_output['outlier_licenses']:
+                    outlier_pkg[dict_lic_pkg[lic]] = lic
+                output['outlier_packages'] = outlier_pkg
             else:
-                list_comp_rep_licenses.append(la_output['representative_license'])
+                output['outlier_packages'] = {}
 
-        # Return if we could not compute license for some component
-        if is_stack_license_possible is False:
-            # output['status'] should have been set already
-            output['stack_license'] = None
-            output['message'] = "Component license not available. Cannot compute stack license."
-            return output
-
-        # If there is no component license then something unexpected happened
-        if len(list_comp_rep_licenses) == 0:
+        except:  # TODO custom exceptions
             output['status'] = 'Failure'
             output['stack_license'] = None
-            output['message'] = "Something weird happened!"
+            output['message'] = "Some unexpected exception happened!"
+            msg = traceback.format_exc()
+            logging.error("Unexpected error happened!\n{}".format(msg))
 
-        # Prepare a map of license -> package, which is used later to prepare output
-        assert(len(output['packages']) == len(list_comp_rep_licenses))
-        dict_lic_pkg = {}
-        for i, lic in enumerate(list_comp_rep_licenses):
-            pkg = output['packages'][i]
-            dict_lic_pkg[lic] = pkg.get('package', 'unknown_package')
-
-        # If we reach here, then that means we are all set to compute stack license !
-        la_output = license_analyzer.compute_representative_license(list_comp_rep_licenses)
-        output['status'] = la_output['status']
-        output['stack_license'] = la_output['representative_license']
-
-        if la_output['status'] == 'Conflict':
-            list_conflict_lic = la_output['conflict_licenses']
-            list_conflict_pkg = []
-            for lic_tuple in list_conflict_lic:
-                pkg_group = {
-                    dict_lic_pkg[lic_tuple[0]]: lic_tuple[0],
-                    dict_lic_pkg[lic_tuple[1]]: lic_tuple[1]
-                }
-                list_conflict_pkg.append(pkg_group)
-            output['conflict_packages'] = list_conflict_pkg
-            output['status'] = 'StackLicenseConflict'
-
-        if (len(la_output['outlier_licenses'])) > 0:
-            outlier_pkg = {}
-            for lic in la_output['outlier_licenses']:
-                outlier_pkg[dict_lic_pkg[lic]] = lic
-            output['outlier_packages'] = outlier_pkg
-        else:
-            output['outlier_packages'] = {}
-
-    except:  # TODO custom exceptions
-        output['status'] = 'Failure'
-        output['stack_license'] = None
-        output['message'] = "Some unexpected exception happened!"
-        msg = traceback.format_exc()
-        logging.error("Unexpected error happened!\n{}".format(msg))
-
-    return output
+        return output

--- a/tests/test_license_analysis.py
+++ b/tests/test_license_analysis.py
@@ -95,3 +95,62 @@ def test_compute_rep_license_conflict_2():
                                   ('lgplv2.1', 'mpl 1.1'),
                                   ('lgplv3+', 'mpl 1.1')]
     assert set(expected_conflict_licenses) == set(output['conflict_licenses'])
+
+
+def test_check_compatibility():
+    src_dir = "license_graph"
+    graph_store = LocalFileSystem(src_dir=src_dir)
+    synonyms_dir = "synonyms"
+    synonyms_store = LocalFileSystem(src_dir=synonyms_dir)
+    license_analyzer = LicenseAnalyzer(graph_store, synonyms_store)
+
+    lic_a = 'APACHE'
+    list_lic_b = []
+    output = license_analyzer.check_compatibility(lic_a, list_lic_b)
+    assert output['status'] == 'Failure'
+    assert output['reason'] == 'Input is invalid'
+
+    lic_a = 'APACHE'
+    list_lic_b = ['abcd', 'xyz']  # some unknown
+    output = license_analyzer.check_compatibility(lic_a, list_lic_b)
+    assert output['status'] == 'Failure'
+    assert output['reason'] == 'All the input licenses are unknown!'
+    unknown_licenses = set(output['unknown_licenses'])
+    assert unknown_licenses == set(['abcd', 'xyz'])
+
+    lic_a = 'APACHE'
+    list_lic_b = ['PD', 'MIT', 'BSD']  # all permissive
+    output = license_analyzer.check_compatibility(lic_a, list_lic_b)
+    assert output['status'] == 'Successful'
+    assert len(output['compatible_licenses']) == 1
+    compatible_licenses = set(output['compatible_licenses'][0])
+    assert compatible_licenses == set(['public domain', 'mit', 'bsd-new'])
+
+    lic_a = 'PD'
+    list_lic_b = ['PD', 'MIT', 'BSD']  # all permissive
+    output = license_analyzer.check_compatibility(lic_a, list_lic_b)
+    assert output['status'] == 'Successful'
+    assert len(output['compatible_licenses']) == 1
+    compatible_licenses = set(output['compatible_licenses'][0])
+    assert compatible_licenses == set(['public domain', 'mit', 'bsd-new'])
+
+    lic_a = 'PD'
+    list_lic_b = ['APACHE', 'MIT']
+    output = license_analyzer.check_compatibility(lic_a, list_lic_b)
+    assert output['status'] == 'Successful'
+    assert len(output['compatible_licenses']) == 2
+    compatible_licenses1 = set(output['compatible_licenses'][0])
+    compatible_licenses2 = set(output['compatible_licenses'][1])
+    assert (compatible_licenses2 == set(['mit', 'apache 2.0']) or compatible_licenses1 == set(['mit', 'apache 2.0']))
+    assert (compatible_licenses2 == set(['mit']) or compatible_licenses1 == set(['mit']))
+
+    lic_a = 'APACHE'
+    list_lic_b = ['MIT', 'lgplv2.1', 'MPL 1.1']
+    output = license_analyzer.check_compatibility(lic_a, list_lic_b)
+    assert output['status'] == 'Successful'
+    assert len(output['compatible_licenses']) == 1
+    compatible_licenses = set(output['compatible_licenses'][0])
+    assert compatible_licenses == set(['mit', 'lgplv2.1'])
+    assert len(output['conflict_licenses']) == 1
+    conflict_licenses = set(output['conflict_licenses'][0])
+    assert conflict_licenses == set('mpl 1.1')

--- a/tests/test_stack_license.py
+++ b/tests/test_stack_license.py
@@ -1,22 +1,26 @@
-from src.stack_license import compute_stack_license
+from src.stack_license import StackLicenseAnalyzer
+
+
+# single instance of stack license analyzer
+stack_license_analyzer = StackLicenseAnalyzer()
 
 
 def test_component_license_conflict():
     payload = {
         'packages': [
             {
-                'name': 'p1',
+                'package': 'p1',
                 'version': '1.1',
                 'licenses': ['APACHE', 'PD']
             },
             {
-                'name': 'p2',
+                'package': 'p2',
                 'version': '1.1',
                 'licenses': ['APACHE', 'GPL V2']
             }
         ]
     }
-    output = compute_stack_license(payload=payload)
+    output = stack_license_analyzer.compute_stack_license(payload=payload)
     assert output is not None
     assert output['status'] == 'ComponentLicenseConflict'
     assert output['stack_license'] is None
@@ -26,18 +30,18 @@ def test_stack_license_conflict():
     payload = {
         'packages': [
             {
-                'name': 'p1',
+                'package': 'p1',
                 'version': '1.1',
                 'licenses': ['APACHE', 'PD']
             },
             {
-                'name': 'p2',
+                'package': 'p2',
                 'version': '1.1',
                 'licenses': ['BSD', 'GPL V2']
             }
         ]
     }
-    output = compute_stack_license(payload=payload)
+    output = stack_license_analyzer.compute_stack_license(payload=payload)
     assert output is not None
     assert output['status'] == 'StackLicenseConflict'
     assert output['stack_license'] is None
@@ -47,18 +51,56 @@ def test_stack_license_successful():
     payload = {
         'packages': [
             {
-                'name': 'p1',
+                'package': 'p1',
                 'version': '1.1',
                 'licenses': ['MIT', 'PD']
             },
             {
-                'name': 'p2',
+                'package': 'p2',
                 'version': '1.1',
                 'licenses': ['BSD', 'GPL V2']
             }
         ]
     }
-    output = compute_stack_license(payload=payload)
+    output = stack_license_analyzer.compute_stack_license(payload=payload)
+    assert output is not None
+    assert output['status'] == 'Successful'
+    assert output['stack_license'] == 'gplv2'
+
+
+def test_stack_license_filter():
+    payload = {
+        'packages': [
+            {
+                'package': 'p1',
+                'version': '1.1',
+                'licenses': ['MIT', 'PD']
+            },
+            {
+                'package': 'p2',
+                'version': '1.1',
+                'licenses': ['BSD', 'GPL V2']
+            }
+        ],
+        'alternate_packages': [
+            {
+                'package': 'p11',
+                'version': '1.1',
+                'licenses': ['APACHE']
+            },
+            {
+                'package': 'p21',
+                'version': '1.1',
+                'licenses': ['BSD', 'GPL V2']
+            },
+            {
+                'package': 'p31',
+                'version': '1.1',
+                'licenses': ['ABCD', 'XYZ']
+            }
+        ]
+    }
+    output = stack_license_analyzer.compute_stack_license(payload=payload)
     assert output is not None
     assert output['status'] == 'Successful'
     assert output['stack_license'] == 'gplv2'
@@ -68,18 +110,18 @@ def test_component_license_unknown():
     payload = {
         'packages': [
             {
-                'name': 'p1',
+                'package': 'p1',
                 'version': '1.1',
                 'licenses': ['MIT', 'SOME_JUNK']
             },
             {
-                'name': 'p2',
+                'package': 'p2',
                 'version': '1.1',
                 'licenses': ['BSD', 'GPL V2']
             }
         ]
     }
-    output = compute_stack_license(payload=payload)
+    output = stack_license_analyzer.compute_stack_license(payload=payload)
     assert output is not None
     assert output['status'] == 'Unknown'
     assert output['stack_license'] is None


### PR DESCRIPTION
Added a feature to generate license filter information along with regular license analysis.

Now, the stack license analysis end point will also accept recommended alternate and companion packages in the input. If the stack license is possible ( i.e. no unknown and no conflict ) then the service will also generate information for license based filters.

The license filter info will have three pieces:
 1. unknown licenses packages
 2. conflict packages
 3. compatible packages

Thanks,
Harjinder