### PR TITLE
Wrong sanity check test

### DIFF
--- a/tests/test_stack_license.py
+++ b/tests/test_stack_license.py
@@ -9,6 +9,18 @@ stack_license_analyzer = StackLicenseAnalyzer()
 
 def test_input_sanity_checks():
     """Check if the method compute_stack_license perform input sanity checking."""
+    payload = None
+    output = stack_license_analyzer.compute_stack_license(payload=payload)
+    assert output is not None
+    assert output['status'] == 'Failure'
+    assert output['message'] == 'Input was invalid'
+
+    payload = {}
+    output = stack_license_analyzer.compute_stack_license(payload=payload)
+    assert output is not None
+    assert output['status'] == 'Failure'
+    assert output['message'] == 'Input was invalid'
+
     payload = {
         'packages': []
     }


### PR DESCRIPTION
Test for the misplaced sanity check. The check is placed at line 107:

https://github.com/fabric8-analytics/fabric8-analytics-license-analysis/blob/master/src/stack_license.py#L107

But it must be performed anywhere before line 102 (+ would be better to check for the presence of 'packages' entry):

https://github.com/fabric8-analytics/fabric8-analytics-license-analysis/blob/master/src/stack_license.py#L102

So -> the test failure is expected here